### PR TITLE
Fix link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Coveralls Reborn](http://coveralls.io) for Ruby [![Coverage Status](https://coveralls.io/repos/github/tagliala/coveralls-ruby-reborn/badge.svg?branch=master)](https://coveralls.io/github/tagliala/coveralls-ruby-reborn?branch=master) [![Build Status](https://secure.travis-ci.org/tagliala/coveralls-ruby-reborn.svg?branch=master)](https://travis-ci.org/tagliala/coveralls-ruby-reborn) [![Gem Version](https://badge.fury.io/rb/coveralls_reborn.svg)](http://badge.fury.io/rb/coveralls_reborn)
 
-### [Read the docs &rarr;](https://coveralls.zendesk.com/hc/en-us/articles/201769485-Ruby-Rails)
+### [Read the docs &rarr;](https://docs.coveralls.io/ruby-on-rails)
 
 An up-to-date fork of [lemurheavy/coveralls-ruby](https://github.com/lemurheavy/coveralls-ruby)
 


### PR DESCRIPTION
Should go to https://docs.coveralls.io/ruby-on-rails

Fixes #2 