### PR TITLE
Remove dep on JSON gem

### DIFF
--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |gem|
   }
   gem.required_ruby_version = '>= 2.4'
 
-  gem.add_dependency 'json', '~> 2.1'
   gem.add_dependency 'simplecov', '~> 0.18.1'
   gem.add_dependency 'term-ansicolor', '~> 1.6'
   gem.add_dependency 'thor', '>= 0.20.3', '< 2.0'


### PR DESCRIPTION
This was clashing with another gem that depends on `json`. As far as I'm aware `json`'s in the stdlib so this isn't necessary.