### PR TITLE
Refactor HTTP Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master / unreleased
+
+* [ENHANCEMENT] Refactor HTTP client [#10](https://github.com/tagliala/coveralls-ruby-reborn/pull/10)
+
 ## 0.17.0 / 2020-08-26
 
 * [FEATURE] Add SimpleCov 0.19.0 compatibility

--- a/lib/coveralls/api.rb
+++ b/lib/coveralls/api.rb
@@ -80,15 +80,7 @@ module Coveralls
 
       def build_client(uri)
         client = Net::HTTP.new(uri.host, uri.port)
-        client.use_ssl = true if uri.port == 443
-        client.verify_mode = OpenSSL::SSL::VERIFY_NONE
-
-        unless client.respond_to?(:ssl_version=)
-          Net::HTTP.ssl_context_accessor('ssl_version')
-        end
-
-        client.ssl_version = 'SSLv23'
-
+        client.use_ssl = uri.port == 443
         client
       end
 


### PR DESCRIPTION
- Don’t set verify mode to None
- `Net::HTTP` clients respond to `ssl_version` in all supported ruby
   versions.
- Allow for auto SSL negotiation

Fix: #7