### PR TITLE
Send branches coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## main / unreleased
+
+* [FEATURE] Send branches coverage [#27](https://github.com/tagliala/coveralls-ruby-reborn/pull/27/files)
+
 ## 0.22.0 / 2021-04-30
 
 * [FEATURE] Drop Ruby 2.4 support

--- a/lib/coveralls/simplecov.rb
+++ b/lib/coveralls/simplecov.rb
@@ -45,6 +45,7 @@ module Coveralls
 
           # Get the coverage
           properties[:coverage] = file.coverage_data['lines']
+          properties[:branches] = branches(file.coverage_data['branches']) if file.coverage_data['branches']
 
           # Skip nocov lines
           file.lines.each_with_index do |line, i|
@@ -55,6 +56,19 @@ module Coveralls
         end
 
         source_files
+      end
+
+      def branches(simplecov_branches)
+        branches_properties = []
+        simplecov_branches.each do |branch_data, data|
+          branch_number = 0
+          line_number = branch_data.split(', ')[2].to_i
+          data.each_value do |hits|
+            branch_number += 1
+            branches_properties.concat([line_number, 0, branch_number, hits])
+          end
+        end
+        branches_properties
       end
 
       def format(result)

--- a/spec/coveralls/fixtures/app/models/user.rb
+++ b/spec/coveralls/fixtures/app/models/user.rb
@@ -7,4 +7,10 @@ class Foo
   def bar
     @foo
   end
+
+  def foo
+    if @foo
+      'bar'
+    end
+  end
 end


### PR DESCRIPTION
Hi, I was looking coverage results for branches to found out that the info is simple not send through [the API](https://docs.coveralls.io/api-reference#branches). 

Here an example with branches coverage:  [coveralls](https://coveralls.io/builds/42411252/source?filename=lib%2Fbright_serializer%2Fserializer.rb#L36)

I inspired myself with the [python librairie](https://github.com/TheKevJames/coveralls-python/blob/4120c540d5dceb065c094fc80400c8258be3502b/coveralls/reporter.py#L166).


