### PR TITLE
Fix configuration for Semaphore CI

### DIFF
--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -76,8 +76,8 @@ module Coveralls
 
       def define_service_params_for_semaphore(config)
         config[:service_name]         = 'semaphore'
-        config[:service_number]       = ENV['SEMAPHORE_BUILD_NUMBER']
-        config[:service_pull_request] = ENV['PULL_REQUEST_NUMBER']
+        config[:service_number]       = ENV['SEMAPHORE_WORKFLOW_ID']
+        config[:service_branch]       = ENV['SEMAPHORE_GIT_BRANCH']
       end
 
       def define_service_params_for_jenkins(config)


### PR DESCRIPTION
The configuration for Semaphore CI currently relies on two environmental variables that aren't defined: `ENV['SEMAPHORE_BUILD_NUMBER']` and `ENV['PULL_REQUEST_NUMBER']`.

The PR uses instead `ENV['SEMAPHORE_WORKFLOW_ID']` as `service_number` and `ENV['SEMAPHORE_GIT_BRANCH']` as `service_branch`.

Unfortunately, Semaphore CI doesn't provide the reference to the PR in the environmental variables so `service_pull_request` cannot be set.