### PR TITLE
Add Buildkite CI support

### DIFF
--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -45,6 +45,8 @@ module Coveralls
           define_service_params_for_tddium(config)
         elsif ENV['GITLAB_CI']
           define_service_params_for_gitlab(config)
+        elsif ENV['BUILDKITE']
+          define_service_params_for_buildkite(config)
         elsif ENV['COVERALLS_RUN_LOCALLY'] || Coveralls.testing
           define_service_params_for_coveralls_local(config)
         end
@@ -116,6 +118,16 @@ module Coveralls
         config[:service_job_id]     = ENV['CI_BUILD_ID']
         config[:service_branch]     = ENV['CI_BUILD_REF_NAME']
         config[:commit_sha]         = ENV['CI_BUILD_REF']
+      end
+
+      def define_service_params_for_buildkite(config)
+        config[:service_name]         = 'buildkite'
+        config[:service_number]       = ENV['BUILDKITE_BUILD_NUMBER']
+        config[:service_job_id]       = ENV['BUILDKITE_BUILD_ID']
+        config[:service_branch]       = ENV['BUILDKITE_BRANCH']
+        config[:service_build_url]    = ENV['BUILDKITE_BUILD_URL']
+        config[:service_pull_request] = ENV['BUILDKITE_PULL_REQUEST']
+        config[:commit_sha]           = ENV['BUILDKITE_COMMIT']
       end
 
       def define_service_params_for_coveralls_local(config)

--- a/spec/coveralls/configuration_spec.rb
+++ b/spec/coveralls/configuration_spec.rb
@@ -85,6 +85,7 @@ describe Coveralls::Configuration do
           appveyor:        'APPVEYOR',
           circleci:        'CIRCLECI',
           gitlab:          'GITLAB_CI',
+          buildkite:       'BUILDKITE',
           jenkins:         'JENKINS_URL',
           semaphore:       'SEMAPHORE',
           tddium:          'TDDIUM',
@@ -144,6 +145,10 @@ describe Coveralls::Configuration do
 
       context 'when using GitLab CI' do
         it_behaves_like 'a service', :gitlab
+      end
+
+      context 'when using Buildkite' do
+        it_behaves_like 'a service', :buildkite
       end
 
       context 'when using Jenkins' do
@@ -253,6 +258,38 @@ describe Coveralls::Configuration do
         service_job_id:     service_job_id,
         service_branch:     service_branch,
         commit_sha:         commit_sha
+      )
+    end
+  end
+
+  describe '.define_service_params_for_buildkite' do
+    let(:service_number) { 5678 }
+    let(:service_job_id) { 1234 }
+    let(:service_branch) { 'feature' }
+    let(:service_build_url) { SecureRandom.hex(4) }
+    let(:service_pull_request) { SecureRandom.hex(4) }
+    let(:commit_sha) { SecureRandom.hex(32) }
+
+    before do
+      allow(ENV).to receive(:[]).with('BUILDKITE_BUILD_NUMBER').and_return(service_number)
+      allow(ENV).to receive(:[]).with('BUILDKITE_BUILD_ID').and_return(service_job_id)
+      allow(ENV).to receive(:[]).with('BUILDKITE_BRANCH').and_return(service_branch)
+      allow(ENV).to receive(:[]).with('BUILDKITE_BUILD_URL').and_return(service_build_url)
+      allow(ENV).to receive(:[]).with('BUILDKITE_PULL_REQUEST').and_return(service_pull_request)
+      allow(ENV).to receive(:[]).with('BUILDKITE_COMMIT').and_return(commit_sha)
+    end
+
+    it 'sets the expected parameters' do
+      config = {}
+      described_class.define_service_params_for_buildkite(config)
+      expect(config).to include(
+        service_name:         'buildkite',
+        service_number:       service_number,
+        service_job_id:       service_job_id,
+        service_branch:       service_branch,
+        service_build_url:    service_build_url,
+        service_pull_request: service_pull_request,
+        commit_sha:           commit_sha
       )
     end
   end


### PR DESCRIPTION
I've adjusted the default env. vars [available for Buildkite](https://buildkite.com/docs/pipelines/environment-variables) to work with the gem's config and it looks as expected in the coveralls side.
<img width="1122" alt="Screen Shot 2023-02-14 at 3 47 44 PM" src="https://user-images.githubusercontent.com/475834/218626168-ad101ddc-557d-4b10-91b3-2db424d332e8.png">
