### PR TITLE
Fix typo require name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ For a Ruby app:
 # ./test/test_helper.rb
 # ..etc..
 
-require 'coveralls_reborn'
+require 'coveralls'
 Coveralls.wear!
 ```
 
 For a Rails app:
 
 ```ruby
-require 'coveralls_reborn'
+require 'coveralls'
 Coveralls.wear!('rails')
 ```
 
@@ -99,7 +99,7 @@ directly:
 
 ```ruby
 require 'simplecov'
-require 'coveralls_reborn'
+require 'coveralls'
 
 SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 SimpleCov.start do
@@ -111,7 +111,7 @@ Or alongside another formatter, like so:
 
 ```ruby
 require 'simplecov'
-require 'coveralls_reborn'
+require 'coveralls'
 
 SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
@@ -130,7 +130,7 @@ formatter, simply omit the Coveralls formatter, then add the rake task `coverall
 `Rakefile` as a dependency to your testing task, like so:
 
 ```ruby
-require 'coveralls_reborn/rake/task'
+require 'coveralls/rake/task'
 Coveralls::RakeTask.new
 task :test_with_coveralls => [:spec, :features, 'coveralls:push']
 ```


### PR DESCRIPTION
`coveralls_reborn` is the name of this gem, but it appears that it needs to be required as `coveralls` when using it.

```
$ bundle list | grep coveralls_reborn
  * coveralls_reborn (0.28.0)

$ bundle exec irb
irb(main):001:0> require 'coveralls_reborn'
(irb):1:in `require': cannot load such file -- coveralls_reborn (LoadError)

(snip)

irb(main):002:0> require 'coveralls'
=> true
```