### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Run specs
       run: JRUBY_OPTS="--dev --debug" bundle exec rake spec
     - name: Coveralls Parallel
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}
         flag-name: run-${{ matrix.ruby-version }}
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}
         parallel-finished: true

--- a/lib/coveralls.rb
+++ b/lib/coveralls.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'coveralls/version'
-require 'coveralls/configuration'
-require 'coveralls/api'
-require 'coveralls/output'
-require 'coveralls/simplecov'
+require_relative 'coveralls/version'
+require_relative 'coveralls/configuration'
+require_relative 'coveralls/api'
+require_relative 'coveralls/output'
+require_relative 'coveralls/simplecov'
 
 module Coveralls
   class << self


### PR DESCRIPTION
`require_relative` is preferred over `require` for files within the same project because it uses paths relative to the current file, making code more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for consistency, performance, and improved portability.

Ref:
- rubocop/rubocop#8748