### PR TITLE
Fix default exclude

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,8 +10,10 @@ AllCops:
   ExtraDetails: true
   TargetRubyVersion: 2.6
   Exclude:
-    - 'spec/coveralls/fixtures/**/*'
-    - 'vendor/bundle/**/*'
+    - .git/**/*
+    - spec/coveralls/fixtures/**/*
+    - tmp/**/*
+    - vendor/**/*
 
 Layout/HashAlignment:
   EnforcedColonStyle: table


### PR DESCRIPTION
When customizing `AllCops::Exclude`, RuboCop does not inherit from the default exclusion list

This commit ignores some folders to speed up RuboCop